### PR TITLE
use `pathToFileURL`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const Module = require('module');
 const {isAbsolute} = require('path');
 
@@ -15,6 +16,9 @@ async function importEsm(specifier, module) {
             resolvedPath = req.resolve(Path.posix.join(specifier, 'package.json'));
         } catch {
             resolvedPath = req.resolve(specifier);
+        }
+        if(os.platform() === "win32") {
+            resolvedPath = 'file://' + resolvedPath
         }
     } catch {
         throw new Error(`Unable to locate module "${specifier}" relative to "${module?.filename}" using the CommonJS resolver.  Consider passing an absolute path to the target module.`);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const os = require('os');
 const Module = require('module');
 const {isAbsolute} = require('path');
+const {pathToFileURL} = require('url')
 
 exports.dynamicImport = importEsm;
 exports.importEsm = importEsm;
@@ -17,9 +17,7 @@ async function importEsm(specifier, module) {
         } catch {
             resolvedPath = req.resolve(specifier);
         }
-        if(os.platform() === "win32") {
-            resolvedPath = 'file://' + resolvedPath
-        }
+        resolvedPath = pathToFileURL(resolvedPath).href;
     } catch {
         throw new Error(`Unable to locate module "${specifier}" relative to "${module?.filename}" using the CommonJS resolver.  Consider passing an absolute path to the target module.`);
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const Module = require('module');
 const {isAbsolute} = require('path');
-const {pathToFileURL} = require('url')
+const {pathToFileURL} = require('url');
 
 exports.dynamicImport = importEsm;
 exports.importEsm = importEsm;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ exports.importEsm = importEsm;
 
 async function importEsm(specifier, module) {
     if(isAbsolute(specifier)) {
-        return import(specifier);
+        return import(pathToFileURL(specifier).href);
     }
     let resolvedPath;
     try {


### PR DESCRIPTION
After v0.0.4 update, I found a small issue while working on windows. 

This is error log I got (I'm using yarn 3.5.0)
```text
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:399:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1059:11) 
    at defaultResolve (node:internal/modules/esm/resolve:1135:3)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at resolve$1 (file:///C:/Users/kracc/Desktop/code/dimipay/.pnp.loader.mjs:1966:14)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)        
    at ESMLoader.import (node:internal/modules/esm/loader:525:22)
    at importModuleDynamically (node:internal/modules/cjs/loader:1186:29) {    
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
````
The reason is that `resolvedPath` does not contain `file://` protocol on windows - fixing with `pathToFileURL`