### PR TITLE
Use pathToFileURL (Windows fix)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const Module = require('module');
 const {isAbsolute} = require('path');
+const { pathToFileURL } = require('url');
 
 exports.dynamicImport = importEsm;
 exports.importEsm = importEsm;
@@ -19,5 +20,5 @@ async function importEsm(specifier, module) {
     } catch {
         throw new Error(`Unable to locate module "${specifier}" relative to "${module?.filename}" using the CommonJS resolver.  Consider passing an absolute path to the target module.`);
     }
-    return import(resolvedPath);
+    return import(pathToFileURL(resolvedPath).href);
 }


### PR DESCRIPTION
I was doing this:
```ts
import { dynamicImport } from "tsimportlib";
//...
const { default: filterAsync } = (await dynamicImport(
    "node-filter-async",
    module,
  )) as typeof import("node-filter-async");
```

And was getting this:
```
Error: Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:399:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:972:11)
    at defaultResolve (node:internal/modules/esm/resolve:1051:3)
    at DefaultModuleLoader.resolve (node:internal/modules/esm/loader:307:12)
    at DefaultModuleLoader.getModuleJob (node:internal/modules/esm/loader:156:32)
    at DefaultModuleLoader.import (node:internal/modules/esm/loader:266:12)
    at importModuleDynamically (node:internal/modules/cjs/loader:1197:37)
    at importModuleDynamicallyWrapper (node:internal/vm/module:428:21)
    at importModuleDynamically (node:internal/vm:105:46)
    at importModuleDynamicallyCallback (node:internal/modules/esm/utils:87:14) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
```

Fix inspired by https://github.com/nuxt/nuxt/pull/19676